### PR TITLE
Search subfolders for images

### DIFF
--- a/qml/custom/Utils.js
+++ b/qml/custom/Utils.js
@@ -50,3 +50,7 @@ function humanDurationLong(seconds){
     if (sec     < 10) {sec = "0"+sec;}
     return hours+':'+minutes+':'+sec;
 }
+
+function defaultName(){
+    return Qt.formatDateTime(new Date(), "yyyy-MM-dd-HH:mm")
+}

--- a/qml/pages/Capture.qml
+++ b/qml/pages/Capture.qml
@@ -34,7 +34,7 @@ import "../custom/Utils.js" as Utils
 Page {
     id: capturePage
 
-    property string name: Qt.formatDateTime(new Date())
+    property string name: Utils.defaultName()
     property var camera: null
     property int interval: 1000
     property string baseDir: ""

--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -30,6 +30,12 @@ import harbour.timelapsetools 1.0
 Page {
     id: mainPage
 
+    onStatusChanged: {
+        if (status == PageStatus.Activating) {
+            timeLapseModel.update()
+        }
+    }
+
     SilicaListView {
         id: listView
 
@@ -129,6 +135,7 @@ Page {
                                            function() {
                                                console.log("about delete timelapse on row " + model.index);
                                                timeLapseModel.deleteTimeLapse(model.index);
+                                               timeLapseModel.update()
                                            });
                     }
                 }

--- a/qml/pages/NewTimeLapsePage.qml
+++ b/qml/pages/NewTimeLapsePage.qml
@@ -36,6 +36,7 @@ Page {
 
     allowedOrientations: Orientation.Landscape
     property var camera: null
+    property bool validates: nameField.acceptableInput
 
     property int settingWidth: Math.min(newTimeLapsePage.width / 3, 1200)
 
@@ -263,8 +264,8 @@ Page {
             TextField {
                 id: nameField
                 label: qsTr("Name")
-                text: Qt.formatDateTime(new Date())
-                validator: RegExpValidator { regExp: /[^\/*:]{1,}/ }
+                text: Utils.defaultName()
+                validator: RegExpValidator { regExp: /[^\/*\\]{1,}/ }
             }
             TextField {
                 id: intervalField
@@ -672,7 +673,7 @@ Page {
         border.width: 5
         border.color: "white"
         color: "red"
-        visible: camera != null
+        visible: (camera != null) && newTimeLapsePage.validates
 
         MouseArea {
             anchors.fill: parent

--- a/src/TimeLapseModel.h
+++ b/src/TimeLapseModel.h
@@ -57,9 +57,10 @@ public:
   Q_INVOKABLE QVariant data(const QModelIndex &index, int role) const override;
   QHash<int, QByteArray> roleNames() const override;
   Q_INVOKABLE Qt::ItemFlags flags(const QModelIndex &index) const override;
+  Q_INVOKABLE void update();
 
 private:
-  void update();
+  void checkDir(QDir const &dir);
 
 private:
   QFileSystemWatcher dirWatcher;


### PR DESCRIPTION
Instead of searching the directory just for subdirectories, the
timelapse model now searches recursively through the subdirectories for
any directory containing jpeg/jpg images.

The model is also forced to recheck for changes every time the main page
is returned to, so that any changes to subdirectories are picked up as
well.

Fixes #2.